### PR TITLE
Better conventions and Advocate forms

### DIFF
--- a/src/app/advocates/[id]/page.tsx
+++ b/src/app/advocates/[id]/page.tsx
@@ -2,22 +2,73 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import { Advocate } from "@/types/types";
+import { Advocate, UpdateAdvocateValues } from "@/types/types";
+import { Button, Card, Modal, ModalBody, ModalHeader } from "flowbite-react";
+import AdvocateForm from "@/app/forms/AdvocateForm";
+import api from "@/services/api";
 
 export default function AdvocatePage() {
   const params = useParams();
+  const [openModal, setOpenModal] = useState(false);
   const [advocate, setAdvocate] = useState<Advocate>();
 
+  const fetchAdvocate = async () => {
+    const advocate = await api.advocates.fetchAdvocate(`${params.id}`);
+    setAdvocate(advocate);
+  };
+  const handleSubmit = async (data: UpdateAdvocateValues) => {
+    const updatedAdvocate = await api.advocates.updateAdvocate(
+      `${params.id}`,
+      data
+    );
+
+    setAdvocate(updatedAdvocate);
+  };
+
   useEffect(() => {
-    console.log("fetching advocates...");
-    fetch(`/api/advocates/${params.id}`).then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocate(jsonResponse.data);
-      });
-    });
+    fetchAdvocate();
   }, []);
 
   if (!advocate) return null;
 
-  return <div>{advocate.firstName}</div>;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <Card
+        className="w-full max-w-sm text-center"
+        imgSrc="https://picsum.photos/200"
+      >
+        <div className="flex flex-col items-center pb-10">
+          <h5 className="mb-1 text-xl font-medium text-gray-900 dark:text-white">
+            {advocate.firstName} {advocate.lastName}
+          </h5>
+          <span className="text-sm text-gray-500 dark:text-gray-400">
+            {advocate.specialties.map(
+              (specialties) => specialties.specialty.name
+            )}
+          </span>
+          <div className="mt-4 flex space-x-3 lg:mt-6">
+            <Button
+              color="alternative"
+              size="md"
+              onClick={() => setOpenModal(true)}
+            >
+              Edit
+            </Button>
+          </div>
+        </div>
+      </Card>
+      <Modal show={openModal} onClose={() => setOpenModal(false)} size="xl">
+        <ModalHeader>Update Advocate Name</ModalHeader>
+        <ModalBody className="max-w-3xl">
+          <AdvocateForm
+            initialValues={{
+              firstName: advocate.firstName,
+              lastName: advocate.lastName,
+            }}
+            onSubmit={handleSubmit}
+          />
+        </ModalBody>
+      </Modal>
+    </div>
+  );
 }

--- a/src/app/advocates/page.tsx
+++ b/src/app/advocates/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Advocate, AdvocatesSearch } from "@/types/types";
 import { useEffect, useState } from "react";
 import { Card } from "flowbite-react";
 import AdvocatesTable from "@/components/AdvocatesTable";
 import AdvocateSearchForm from "../forms/AdvocateForm";
 import api from "@/services/api";
+import { Advocate, AdvocatesSearch } from "../../types/types";
 
 const Advocates = () => {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);

--- a/src/app/advocates/page.tsx
+++ b/src/app/advocates/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { Card } from "flowbite-react";
 import AdvocatesTable from "@/components/AdvocatesTable";
-import AdvocateSearchForm from "../forms/AdvocateForm";
+import AdvocateSearchForm from "../forms/AdvocatesSearchForm";
 import api from "@/services/api";
 import { Advocate, AdvocatesSearch } from "../../types/types";
 

--- a/src/app/api/advocates/[id]/route.ts
+++ b/src/app/api/advocates/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse, NextRequest } from 'next/server';
 import db from "../../../../db";
 import { Advocate } from '@/types/types';
+import { advocates } from '@/db/schema/advocates';
+import { eq } from 'drizzle-orm';
 
 
 
@@ -21,4 +23,26 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
 
 
     return NextResponse.json({ data }, { status: 200 });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+    const advocateId = Number(params.id);
+    const data = await req.json();
+
+    await db.update(advocates)
+        .set(data)
+        .where(eq(advocates.id, advocateId))
+
+    const updatedAdvocate = await db.query.advocates.findFirst({
+        where: (advocates, { eq }) => eq(advocates.id, advocateId),
+        with: {
+            specialties: {
+                with: {
+                    specialty: true,
+                },
+            },
+        },
+    });
+
+    return NextResponse.json({ data: updatedAdvocate });
 }

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,6 +1,6 @@
-import db from "../../../db";
 import { ilike, or } from "drizzle-orm";
 import { advocates } from '@/db/schema/advocates';
+import db from "../../../db";
 
 
 export async function GET(request: Request) {

--- a/src/app/forms/AdvocateForm/index.tsx
+++ b/src/app/forms/AdvocateForm/index.tsx
@@ -1,21 +1,27 @@
 import FormInput from "@/components/FormInput";
-import { AdvocatesSearch } from "@/types/types";
+import { UpdateAdvocateValues } from "../../../types/types";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useForm } from "react-hook-form";
 import * as yup from "yup";
+import { Button, Card } from "flowbite-react";
 
-const schema = yup.object({
-  searchTerm: yup.string().matches(/^[A-Za-z ]*$/, "Please enter valid name"),
+const schema = yup.object<UpdateAdvocateValues>({
+  firstName: yup
+    .string()
+    .matches(/^[A-Za-z ]*$/, "Please enter valid first name")
+    .optional(),
+  lastName: yup
+    .string()
+    .matches(/^[A-Za-z ]*$/, "Please enter valid last name")
+    .optional(),
 });
 
-type AdvocateSearchFormProps = {
-  initialValues: {
-    searchTerm: string;
-  };
-  onSubmit: (data: AdvocatesSearch) => void;
+type AdvocateFormProps = {
+  initialValues: UpdateAdvocateValues;
+  onSubmit: (data: UpdateAdvocateValues) => void;
 };
 
-const AdvocateSearchForm: React.FC<AdvocateSearchFormProps> = ({
+const AdvocateForm: React.FC<AdvocateFormProps> = ({
   initialValues,
   onSubmit,
 }) => {
@@ -31,14 +37,25 @@ const AdvocateSearchForm: React.FC<AdvocateSearchFormProps> = ({
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormInput
-        register={register}
-        errors={errors}
-        name="searchTerm"
-        fieldLabel="Search your advocate"
-      />
+      <div className="flex max-w-md flex-col gap-4">
+        <FormInput
+          register={register}
+          errors={errors}
+          name="firstName"
+          fieldLabel="First Name"
+        />
+        <FormInput
+          register={register}
+          errors={errors}
+          name="lastName"
+          fieldLabel="Last Name"
+        />
+        <Button color="alternative" type="submit">
+          Submit Form
+        </Button>
+      </div>
     </form>
   );
 };
 
-export default AdvocateSearchForm;
+export default AdvocateForm;

--- a/src/app/forms/AdvocatesSearchForm/index.tsx
+++ b/src/app/forms/AdvocatesSearchForm/index.tsx
@@ -1,0 +1,46 @@
+import FormInput from "@/components/FormInput";
+import { AdvocatesSearch } from "@/types/types";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useForm } from "react-hook-form";
+import * as yup from "yup";
+
+const schema = yup.object({
+  searchTerm: yup.string().matches(/^[A-Za-z ]*$/, "Please enter valid name"),
+});
+
+type AdvocateSearchFormProps = {
+  initialValues: {
+    searchTerm: string;
+  };
+  onSubmit: (data: AdvocatesSearch) => void;
+};
+
+const AdvocateSearchForm: React.FC<AdvocateSearchFormProps> = ({
+  initialValues,
+  onSubmit,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    defaultValues: initialValues,
+    resolver: yupResolver(schema),
+    mode: "onChange",
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div className="flex max-w-md flex-col gap-4">
+        <FormInput
+          register={register}
+          errors={errors}
+          name="searchTerm"
+          fieldLabel="Search your advocate"
+        />
+      </div>
+    </form>
+  );
+};
+
+export default AdvocateSearchForm;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,7 @@
-import type { Metadata } from "next";
-import {
-  Navbar,
-  NavbarCollapse,
-  NavbarLink,
-  NavbarToggle,
-  ThemeModeScript,
-} from "flowbite-react";
-import Link from "next/link";
-import { Inter } from "next/font/google";
+"use client";
+
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
-
-export const metadata: Metadata = {
-  title: "Solace Candidate Assignment",
-  description: "Show us what you got",
-};
+import AppNavBar from "@/components/NavBar";
 
 const RootLayout = ({
   children,
@@ -24,21 +10,8 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang="en">
-      <head>
-        <ThemeModeScript />
-      </head>
       <body>
-        <Navbar fluid>
-          <NavbarToggle />
-          <NavbarCollapse>
-            <NavbarLink href="/" active as={Link}>
-              Home
-            </NavbarLink>
-            <NavbarLink as={Link} href="advocates">
-              Advocates
-            </NavbarLink>
-          </NavbarCollapse>
-        </Navbar>
+        <AppNavBar />
         {children}
       </body>
     </html>

--- a/src/components/FormInput/index.tsx
+++ b/src/components/FormInput/index.tsx
@@ -20,7 +20,7 @@ const FormInput: React.FC<InputProps> = ({
   return (
     <div>
       <div className="mb-2 block">
-        <Label htmlFor={inputId}>Search Table</Label>
+        <Label htmlFor={inputId}>{fieldLabel}</Label>
       </div>
       <TextInput
         id={inputId}

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,0 +1,31 @@
+import {
+  Navbar,
+  NavbarCollapse,
+  NavbarLink,
+  NavbarToggle,
+  NavbarBrand,
+} from "flowbite-react";
+import Link from "next/link";
+
+const AppNavBar = () => {
+  return (
+    <Navbar fluid className="justify-between">
+      <NavbarBrand href="/">
+        <span className="self-center whitespace-nowrap text-xl font-semibold dark:text-white">
+          Solace
+        </span>
+      </NavbarBrand>
+      <NavbarToggle />
+      <NavbarCollapse>
+        <NavbarLink className="list-none" as={Link} href="/advocates">
+          Home
+        </NavbarLink>
+        <NavbarLink className="list-none" as={Link} href="/advocates">
+          Advocates
+        </NavbarLink>
+      </NavbarCollapse>
+    </Navbar>
+  );
+};
+
+export default AppNavBar;

--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -5,8 +5,6 @@ const postgres = require("postgres");
 const runMigration = async () => {
   if (!process.env.DATABASE_URL) throw new Error("DATABASE_URL is not set");
 
-  console.log(process.env.DATABASE_URL);
-
   const sql = postgres(process.env.DATABASE_URL, { max: 1 });
   const db = drizzle(sql);
   await migrate(db, { migrationsFolder: "drizzle" });

--- a/src/lib/http/index.ts
+++ b/src/lib/http/index.ts
@@ -13,6 +13,7 @@ type API_HTTP = {
 
 const handleApiResponse = async (response: ApiResponse) => {
     const responseBody = await response.json()
+    if (!response.ok) throw new Error('An Error happened')
 
     return responseBody.data
 }

--- a/src/services/api/advocates/index.ts
+++ b/src/services/api/advocates/index.ts
@@ -1,4 +1,4 @@
-import http from '../../http'
+import http from '../../../lib/http'
 import { Advocate } from '@/types/types'
 import { apiRoutes } from '../apiRoutes'
 
@@ -8,7 +8,9 @@ type AdvocatesProps = {
 }
 const advocates = {
     loadAll: async (queryParams?: AdvocatesProps) => http.get(apiRoutes.advocates, queryParams),
-    // createUser: async (payload: Advocate) => http.post(apiRoutes.users.index, payload),
+    updateAdvocate: async (id: string, payload: Partial<Advocate>) => http.patch(`${apiRoutes.advocates}/${id}`, payload),
+    fetchAdvocate: async (id: string) => http.get(`${apiRoutes.advocates}/${id}`),
+
 }
 
 export default advocates

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -21,3 +21,8 @@ export type Specialty = {
 export type AdvocatesSearch = {
     searchTerm?: string
 }
+
+export type UpdateAdvocateValues = {
+    firstName?: string;
+    lastName?: string;
+};


### PR DESCRIPTION
This pr adds the following.

To reduce the amount of boilerplate code being used for fetch, this adds the http service functions that unpacks the data. Keeping things DRY and simple makes it better to scale the product, and having a structure is crucial for that. 
It adds more UI components to the Advocate Page where we see individual advocates, I added this page, I think a feature can view a profile is helpful for advocates and users, Advocates can make changes to their profile, add specialties and the user can view who the advocate is.
Because I've set up the http service convention by defining the api methods to search for advocates it reduces the risk of spelling mistakes, from hardcoding strings. Keeping things cleaner, I've set up the pattern from parent to child so that forms receive initial form values from the parent component and we can initilize forms properly, the text input component is reusable and in this case it is reused to update the advocates name, with runtime validation. Now that the code is in better shape become more boilerplate.
The naming of things are important and after taking a closer look at the code this updates the naming convetions of many functions and objects.
Adds an api util to centralize the logic for data that is going to be fetched by the server, and this can be the landing place for future api data logic.